### PR TITLE
Lagt til tester og endret på litt av oppsettet i GrunnlagspakkeControllerTest

### DIFF
--- a/src/test/kotlin/no/nav/bidrag/grunnlag/TestUtil.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/TestUtil.kt
@@ -36,7 +36,18 @@ class TestUtil {
       grunnlagtypeRequestListe = listOf(
         GrunnlagstypeRequest(
           Grunnlagstype.AINNTEKT.toString(),
-          listOf(PersonIdOgPeriodeRequest("123456789", "2021-01-01", "2022-01-01")))))
+          listOf(PersonIdOgPeriodeRequest("12345678910", "2021-01", "2022-01"))
+        ),
+        GrunnlagstypeRequest(
+          Grunnlagstype.SKATTEGRUNNLAG.toString(),
+          listOf(PersonIdOgPeriodeRequest("12345678910", "2021-01", "2022-01"))
+        ),
+        GrunnlagstypeRequest(
+          Grunnlagstype.UTVIDETBARNETRYGDOGSMAABARNSTILLEGG.toString(),
+          listOf(PersonIdOgPeriodeRequest("12345678910", "2021-01", "2022-01"))
+        )
+      )
+    )
 
 
     fun byggHentGrunnlagspakkeRequest() = HentGrunnlagspakkeRequest(
@@ -113,7 +124,7 @@ class TestUtil {
       byggUtvidetBarnetrygdPeriode()
     )
 
-    fun byggUtvidetBarnetrygdPeriode() : List<UtvidetBarnetrygdPeriode> {
+    fun byggUtvidetBarnetrygdPeriode(): List<UtvidetBarnetrygdPeriode> {
       val utvidetBarnetrygdOgSmaabarnstilleggPeriode = UtvidetBarnetrygdPeriode(
 //        stonadstype = BisysStonadstype.UTVIDET,
         stønadstype = BisysStønadstype.UTVIDET,

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/controller/GrunnlagspakkeControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/controller/GrunnlagspakkeControllerTest.kt
@@ -1,48 +1,48 @@
 package no.nav.bidrag.grunnlag.controller
 
+import no.nav.bidrag.commons.ExceptionLogger
 import no.nav.bidrag.commons.web.HttpHeaderRestTemplate
-import no.nav.bidrag.commons.web.test.HttpHeaderTestRestTemplate
 import no.nav.bidrag.gcp.proxy.consumer.inntektskomponenten.response.HentAinntektListeResponse
 import no.nav.bidrag.grunnlag.BidragGrunnlagLocal
 import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.TEST_PROFILE
 import no.nav.bidrag.grunnlag.TestUtil
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.HentKomplettGrunnlagspakkeResponse
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.OppdaterGrunnlagspakkeRequest
+import no.nav.bidrag.grunnlag.api.grunnlagspakke.OppdaterGrunnlagspakkeResponse
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.OpprettGrunnlagspakkeRequest
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.OpprettGrunnlagspakkeResponse
 import no.nav.bidrag.grunnlag.consumer.bidraggcpproxy.BidragGcpProxyConsumer
 import no.nav.bidrag.grunnlag.consumer.bidraggcpproxy.api.skatt.HentSkattegrunnlagResponse
 import no.nav.bidrag.grunnlag.consumer.familiebasak.FamilieBaSakConsumer
 import no.nav.bidrag.grunnlag.consumer.familiebasak.api.FamilieBaSakResponse
-import no.nav.bidrag.grunnlag.dto.GrunnlagspakkeDto
+import no.nav.bidrag.grunnlag.exception.HibernateExceptionHandler
+import no.nav.bidrag.grunnlag.exception.RestExceptionHandler
+import no.nav.bidrag.grunnlag.exception.custom.CustomExceptionHandler
 import no.nav.bidrag.grunnlag.persistence.repository.GrunnlagspakkeRepository
 import no.nav.bidrag.grunnlag.service.GrunnlagspakkeService
 import no.nav.bidrag.grunnlag.service.PersistenceService
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertAll
+import org.hibernate.HibernateException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.function.Executable
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
-import org.springframework.boot.web.server.LocalServerPort
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.web.util.UriComponentsBuilder
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.http.ResponseEntity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.StatusResultMatchersDsl
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.client.HttpClientErrorException
 
 @DisplayName("GrunnlagspakkeControllerTest")
@@ -50,75 +50,36 @@ import org.springframework.web.client.HttpClientErrorException
 @SpringBootTest(classes = [BidragGrunnlagLocal::class], webEnvironment = WebEnvironment.RANDOM_PORT)
 @EnableMockOAuth2Server
 @AutoConfigureWireMock(port = 0)
-class GrunnlagspakkeControllerTest {
+class GrunnlagspakkeControllerTest(
+  @Autowired val grunnlagspakkeRepository: GrunnlagspakkeRepository,
+  @Autowired val persistenceService: PersistenceService,
+  @Autowired val exceptionLogger: ExceptionLogger
+) {
 
-  @Autowired
-  private lateinit var securedTestRestTemplate: HttpHeaderTestRestTemplate
-
-  @Autowired
-  private lateinit var grunnlagspakkeRepository: GrunnlagspakkeRepository
-
-  @Autowired
-  private lateinit var persistenceService: PersistenceService
-
-  @LocalServerPort
-  private val port = 0
-
-  @Value("\${server.servlet.context-path}")
-  private val contextPath: String? = null
+  private val restTemplate: HttpHeaderRestTemplate = Mockito.mock(HttpHeaderRestTemplate::class.java)
+  private val bidragGcpProxyConsumer: BidragGcpProxyConsumer = BidragGcpProxyConsumer(restTemplate)
+  private val familieBaSakConsumer: FamilieBaSakConsumer = FamilieBaSakConsumer(restTemplate)
+  private val grunnlagspakkeService: GrunnlagspakkeService = GrunnlagspakkeService(persistenceService, familieBaSakConsumer, bidragGcpProxyConsumer)
+  private val grunnlagspakkeController: GrunnlagspakkeController = GrunnlagspakkeController(grunnlagspakkeService)
+  private val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(grunnlagspakkeController)
+    .setControllerAdvice(RestExceptionHandler(exceptionLogger), CustomExceptionHandler(exceptionLogger), HibernateExceptionHandler(exceptionLogger))
+    .build()
 
   @BeforeEach
   fun `init`() {
-    // Sletter alle forekomster
     grunnlagspakkeRepository.deleteAll()
-
-  }
-
-  @Test
-  fun `skal mappe til context path med random port`() {
-    assertThat(makeFullContextPath()).isEqualTo("http://localhost:$port/bidrag-grunnlag")
   }
 
   @Test
   fun `skal opprette ny grunnlagspakke`() {
-
-    // Oppretter ny forekomst av grunnlagspakke
-    val response = securedTestRestTemplate.exchange(
-      fullUrlForNyGrunnlagspakke(),
-      HttpMethod.POST,
-      byggNyGrunnlagspakkeRequest(),
-      OpprettGrunnlagspakkeResponse::class.java
-    )
-
-    assertAll(
-      Executable { assertThat(response).isNotNull() },
-      Executable { assertThat(response?.statusCode).isEqualTo(HttpStatus.OK) },
-      Executable { assertThat(response?.body).isNotNull() },
-    )
-    grunnlagspakkeRepository.deleteAll()
+    opprettGrunnlagspakke(OpprettGrunnlagspakkeRequest(opprettetAv = "X123456"))
   }
 
 
   @Test
   fun `skal oppdatere en grunnlagspakke`() {
 
-    val restTemplate = Mockito.mock(HttpHeaderRestTemplate::class.java)
-    val bidragGcpProxyConsumer = BidragGcpProxyConsumer(restTemplate)
-    val familieBaSakConsumer = FamilieBaSakConsumer(restTemplate)
-    val grunnlagspakkeService = GrunnlagspakkeService(persistenceService, familieBaSakConsumer, bidragGcpProxyConsumer)
-    val grunnlagspakkeController = GrunnlagspakkeController(grunnlagspakkeService)
-
-
-    val nyGrunnlagspakkeOpprettetResponse = grunnlagspakkeController.opprettNyGrunnlagspakke(
-      OpprettGrunnlagspakkeRequest(
-        opprettetAv = "X123456"
-      )
-    )
-
-    assertAll(
-      Executable { assertThat(nyGrunnlagspakkeOpprettetResponse).isNotNull },
-      Executable { assertThat(nyGrunnlagspakkeOpprettetResponse?.body).isNotNull }
-    )
+    val nyGrunnlagspakkeOpprettetResponse = opprettGrunnlagspakke(OpprettGrunnlagspakkeRequest(opprettetAv = "X123456"))
 
     Mockito.`when`(restTemplate.exchange(eq("/inntekt/hent"), eq(HttpMethod.POST), any(), any<Class<HentAinntektListeResponse>>())).thenReturn(
       ResponseEntity(HentAinntektListeResponse(emptyList()), HttpStatus.OK)
@@ -134,44 +95,25 @@ class GrunnlagspakkeControllerTest {
         ResponseEntity(FamilieBaSakResponse(emptyList()), HttpStatus.OK)
       )
 
-    val response =
-      grunnlagspakkeController.oppdaterGrunnlagspakke(TestUtil.byggOppdaterGrunnlagspakkeRequest(nyGrunnlagspakkeOpprettetResponse!!.body!!.grunnlagspakkeId))
+    val oppdaterGrunnlagspakkeResponse = oppdaterGrunnlagspakke(
+      TestUtil.byggOppdaterGrunnlagspakkeRequest(nyGrunnlagspakkeOpprettetResponse.grunnlagspakkeId),
+      OppdaterGrunnlagspakkeResponse::class.java
+    ) { isOk() }
 
-    assertAll(
-      Executable { assertThat(response).isNotNull },
-      Executable { assertThat(response?.statusCode).isEqualTo(HttpStatus.OK) },
-      Executable { assertThat(response?.body).isNotNull },
-      Executable { assertThat(response?.body?.grunnlagtypeResponsListe?.size).isEqualTo(3) }
-    )
+    assertThat(oppdaterGrunnlagspakkeResponse.grunnlagtypeResponsListe.size).isEqualTo(3)
 
-    response?.body?.grunnlagtypeResponsListe?.forEach() { grunnlagstypeResponse ->
+    oppdaterGrunnlagspakkeResponse.grunnlagtypeResponsListe.forEach() { grunnlagstypeResponse ->
       grunnlagstypeResponse.hentGrunnlagkallResponseListe.forEach() { hentGrunnlagkallResponse ->
         assertEquals(hentGrunnlagkallResponse.statuskode, HttpStatus.OK.value())
       }
     }
-
-    grunnlagspakkeRepository.deleteAll()
   }
 
   @Test
   fun `skal oppdatere grunnlagspakke og håndtere rest-kall feil`() {
-    val restTemplate = Mockito.mock(HttpHeaderRestTemplate::class.java)
-    val bidragGcpProxyConsumer = BidragGcpProxyConsumer(restTemplate)
-    val familieBaSakConsumer = FamilieBaSakConsumer(restTemplate)
-    val grunnlagspakkeService = GrunnlagspakkeService(persistenceService, familieBaSakConsumer, bidragGcpProxyConsumer)
-    val grunnlagspakkeController = GrunnlagspakkeController(grunnlagspakkeService)
 
 
-    val nyGrunnlagspakkeOpprettetResponse = grunnlagspakkeController.opprettNyGrunnlagspakke(
-      OpprettGrunnlagspakkeRequest(
-        opprettetAv = "X123456"
-      )
-    )
-
-    assertAll(
-      Executable { assertThat(nyGrunnlagspakkeOpprettetResponse).isNotNull },
-      Executable { assertThat(nyGrunnlagspakkeOpprettetResponse?.body).isNotNull }
-    )
+    val nyGrunnlagspakkeOpprettetResponse = opprettGrunnlagspakke(OpprettGrunnlagspakkeRequest(opprettetAv = "X123456"))
 
     Mockito.`when`(restTemplate.exchange(eq("/inntekt/hent"), eq(HttpMethod.POST), any(), any<Class<HentAinntektListeResponse>>())).thenThrow(
       HttpClientErrorException(HttpStatus.NOT_FOUND)
@@ -186,79 +128,114 @@ class GrunnlagspakkeControllerTest {
         HttpClientErrorException(HttpStatus.NOT_FOUND)
       )
 
-    val response =
-      grunnlagspakkeController.oppdaterGrunnlagspakke(TestUtil.byggOppdaterGrunnlagspakkeRequest(nyGrunnlagspakkeOpprettetResponse!!.body!!.grunnlagspakkeId))
+    val oppdaterGrunnlagspakkeResponse = oppdaterGrunnlagspakke(
+      TestUtil.byggOppdaterGrunnlagspakkeRequest(nyGrunnlagspakkeOpprettetResponse.grunnlagspakkeId),
+      OppdaterGrunnlagspakkeResponse::class.java
+    ) { isOk() }
 
-    assertAll(
-      Executable { assertThat(response).isNotNull },
-      Executable { assertThat(response?.statusCode).isEqualTo(HttpStatus.OK) },
-      Executable { assertThat(response?.body).isNotNull },
-      Executable { assertThat(response?.body?.grunnlagtypeResponsListe?.size).isEqualTo(3) }
-    )
+    assertThat(oppdaterGrunnlagspakkeResponse).isNotNull
+    assertThat(oppdaterGrunnlagspakkeResponse.grunnlagtypeResponsListe.size).isEqualTo(3)
 
-    response?.body?.grunnlagtypeResponsListe?.forEach() { grunnlagstypeResponse ->
+    oppdaterGrunnlagspakkeResponse.grunnlagtypeResponsListe?.forEach() { grunnlagstypeResponse ->
       grunnlagstypeResponse.hentGrunnlagkallResponseListe.forEach() { hentGrunnlagkallResponse ->
         assertEquals(hentGrunnlagkallResponse.statuskode, HttpStatus.NOT_FOUND.value())
       }
     }
-
   }
 
 
   @Test
   fun `skal finne data for en grunnlagspakke`() {
-    val nyGrunnlagspakkeOpprettet = persistenceService.opprettNyGrunnlagspakke(
-      GrunnlagspakkeDto(
-        opprettetAv = "X123456"
-      )
-    )
 
-    // Henter forekomst
-    val response = securedTestRestTemplate.exchange(
-      "${fullUrlForHentGrunnlagspakke()}/${nyGrunnlagspakkeOpprettet.grunnlagspakkeId}",
+    val nyGrunnlagspakkeOpprettetResponse = opprettGrunnlagspakke(OpprettGrunnlagspakkeRequest(opprettetAv = "X123456"))
+
+    val hentGrunnlagspakkeResponse = TestUtil.performRequest(
+      mockMvc,
       HttpMethod.GET,
+      "${GrunnlagspakkeController.GRUNNLAGSPAKKE_HENT}/${nyGrunnlagspakkeOpprettetResponse.grunnlagspakkeId}",
       null,
       HentKomplettGrunnlagspakkeResponse::class.java
-    )
+    ) { isOk() }
 
-    assertAll(
-      Executable { assertThat(response).isNotNull() },
-      Executable { assertThat(response?.statusCode).isEqualTo(HttpStatus.OK) },
-      Executable { assertThat(response?.body).isNotNull },
-      Executable { assertThat(response?.body?.grunnlagspakkeId).isEqualTo(nyGrunnlagspakkeOpprettet.grunnlagspakkeId) },
-    )
-    grunnlagspakkeRepository.deleteAll()
-
-
+    assertNotNull(hentGrunnlagspakkeResponse)
+    assertThat(hentGrunnlagspakkeResponse.grunnlagspakkeId).isEqualTo(nyGrunnlagspakkeOpprettetResponse.grunnlagspakkeId)
   }
 
-  private fun fullUrlForNyGrunnlagspakke(): String {
-    return UriComponentsBuilder.fromHttpUrl(makeFullContextPath() + GrunnlagspakkeController.GRUNNLAGSPAKKE_NY).toUriString()
+  @Test
+  fun `skal fange opp og håndtere Hibernate feil`() {
+    val grunnlagspakkeService = Mockito.mock(GrunnlagspakkeService::class.java)
+    val grunnlagspakkeController = GrunnlagspakkeController(grunnlagspakkeService)
+    val mockMvc = MockMvcBuilders.standaloneSetup(grunnlagspakkeController).setControllerAdvice(HibernateExceptionHandler(exceptionLogger)).build()
+
+    val nyGrunnlagspakkeOpprettetResponse = opprettGrunnlagspakke(OpprettGrunnlagspakkeRequest(opprettetAv = "X123456"))
+
+    Mockito.`when`(grunnlagspakkeService.oppdaterGrunnlagspakke(TestUtil.byggOppdaterGrunnlagspakkeRequest(nyGrunnlagspakkeOpprettetResponse.grunnlagspakkeId)))
+      .thenThrow(HibernateException("Test-melding"))
+
+    val oppdaterGrunnlagspakkeResponse =
+      oppdaterGrunnlagspakke(
+        TestUtil.byggOppdaterGrunnlagspakkeRequest(nyGrunnlagspakkeOpprettetResponse.grunnlagspakkeId),
+        String::class.java,
+        mockMvc
+      ) { isInternalServerError() }
+
+    assertNotNull(oppdaterGrunnlagspakkeResponse)
   }
 
-  private fun fullUrlForOppdaterGrunnlagspakke(): String {
-    return UriComponentsBuilder.fromHttpUrl(makeFullContextPath() + GrunnlagspakkeController.GRUNNLAGSPAKKE_OPPDATER).toUriString()
+  @Test
+  fun `skal fange opp og håndtere forespørsler på grunnlagspakker som ikke eksisterer`() {
+
+    val oppdaterGrunnlagspakkeResponse = oppdaterGrunnlagspakke(TestUtil.byggOppdaterGrunnlagspakkeRequest(1), String::class.java) { isNotFound() }
+
+    assertNotNull(oppdaterGrunnlagspakkeResponse)
+
+    val hentGrunnlagspakkeResponse = TestUtil.performRequest(
+      mockMvc,
+      HttpMethod.GET,
+      "${GrunnlagspakkeController.GRUNNLAGSPAKKE_HENT}/1",
+      null,
+      String::class.java
+    ) { isNotFound() }
+
+    assertNotNull(hentGrunnlagspakkeResponse)
+
+    val settGyldigTilDatoForGrunnlagspakkeResponse = TestUtil.performRequest(
+      mockMvc,
+      HttpMethod.POST,
+      GrunnlagspakkeController.GRUNNLAGSPAKKE_SETTGYLDIGTILDATO,
+      TestUtil.byggSettGyldigTilDatoForGrunnlagspakkeRequest(1),
+      String::class.java
+    ) { isNotFound() }
+
+    assertNotNull(settGyldigTilDatoForGrunnlagspakkeResponse)
   }
 
-  private fun fullUrlForHentGrunnlagspakke(): String {
-    return UriComponentsBuilder.fromHttpUrl(makeFullContextPath() + GrunnlagspakkeController.GRUNNLAGSPAKKE_HENT).toUriString()
+  private fun opprettGrunnlagspakke(opprettGrunnlagspakkeRequest: OpprettGrunnlagspakkeRequest): OpprettGrunnlagspakkeResponse {
+    val nyGrunnlagspakkeOpprettetResponse = TestUtil.performRequest(
+      mockMvc,
+      HttpMethod.POST,
+      GrunnlagspakkeController.GRUNNLAGSPAKKE_NY,
+      opprettGrunnlagspakkeRequest,
+      OpprettGrunnlagspakkeResponse::class.java
+    ) { isOk() }
+
+    assertNotNull(nyGrunnlagspakkeOpprettetResponse)
+
+    return nyGrunnlagspakkeOpprettetResponse
   }
 
-  private fun byggNyGrunnlagspakkeRequest(): HttpEntity<OpprettGrunnlagspakkeRequest> {
-    return initHttpEntity(TestUtil.byggNyGrunnlagspakkeRequest())
-  }
-
-  private fun byggOppdaterGrunnlagspakkeRequest(grunnlagspakkeId: Int): HttpEntity<OppdaterGrunnlagspakkeRequest> {
-    return initHttpEntity(TestUtil.byggOppdaterGrunnlagspakkeRequest(grunnlagspakkeId))
-  }
-
-  private fun makeFullContextPath(): String {
-    return "http://localhost:$port$contextPath"
-  }
-
-  private fun <T> initHttpEntity(body: T): HttpEntity<T> {
-    val httpHeaders = HttpHeaders()
-    httpHeaders.contentType = MediaType.APPLICATION_JSON
-    return HttpEntity(body, httpHeaders)
+  private fun <Response> oppdaterGrunnlagspakke(
+    oppdaterGrunnlagspakkeRequest: OppdaterGrunnlagspakkeRequest,
+    responseType: Class<Response>,
+    customMockMvc: MockMvc? = null,
+    expectedStatus: StatusResultMatchersDsl.() -> Unit
+  ): Response {
+    return TestUtil.performRequest(
+      customMockMvc ?: mockMvc,
+      HttpMethod.POST,
+      GrunnlagspakkeController.GRUNNLAGSPAKKE_OPPDATER,
+      oppdaterGrunnlagspakkeRequest,
+      responseType
+    ) { expectedStatus() }
   }
 }


### PR DESCRIPTION
* Lagt opp til at vi bruker `MockMvc` til å kalle på endepunktene i Controlleren. Gjør det mulig for oss å mocke bestemte deler av det som skjer i applikasjonen.
* Lagt til tester for kall mot `oppdaterGrunnlagspakke`. 
* Lagt til tester for å verifisere exception-håndtering. Både eventuelle db-feil (`HibernateExceptions`), feil i rest-kall videre bakover samt egendefinerte feil.