### PR TITLE
Kan nå starte appen lokalt

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,9 @@
 # Profiles: All
 #
 ####################################################################
+springdoc:
+  swagger-ui:
+    path: /
 
 server:
   servlet:

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagApplicationTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagApplicationTest.kt
@@ -1,6 +1,6 @@
 package no.nav.bidrag.grunnlag
 
-import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.TEST_PROFILE
+import no.nav.bidrag.grunnlag.BidragGrunnlagTest.Companion.TEST_PROFILE
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -12,7 +12,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @ExtendWith(SpringExtension::class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = [BidragGrunnlagLocal::class])
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = [BidragGrunnlagTest::class])
 @ActiveProfiles(TEST_PROFILE)
 @DisplayName("BidragGrunnlag")
 @AutoConfigureWireMock(port = 0)

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagLocal.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagLocal.kt
@@ -1,6 +1,10 @@
 package no.nav.bidrag.grunnlag
 
-import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.TEST_PROFILE
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.LOCAL_PROFILE
+import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.ComponentScan
@@ -8,18 +12,24 @@ import org.springframework.context.annotation.FilterType
 import org.springframework.test.context.ActiveProfiles
 
 @SpringBootApplication
-@ActiveProfiles(TEST_PROFILE)
-@ComponentScan(excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = [BidragGrunnlag::class])])
+@EnableMockOAuth2Server
+@EnableJwtTokenValidation(ignore = ["org.springdoc", "org.springframework"])
+@ActiveProfiles(LOCAL_PROFILE)
+@ComponentScan(excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = [BidragGrunnlag::class, BidragGrunnlagTest::class])])
 class BidragGrunnlagLocal {
-
   companion object {
-    const val TEST_PROFILE = "test"
+    const val LOCAL_PROFILE = "local"
   }
 }
-
 fun main(args: Array<String>) {
-  val profile = if (args.isEmpty()) TEST_PROFILE else args[0]
+  val wireMockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort().dynamicHttpsPort()) //No-args constructor will start on port 8080, no HTTPS
+  wireMockServer.start()
+
+  val profile = if (args.isEmpty()) LOCAL_PROFILE else args[0]
   val app = SpringApplication(BidragGrunnlagLocal::class.java)
   app.setAdditionalProfiles(profile)
   app.run(*args)
+
+  wireMockServer.resetAll()
+  wireMockServer.stop()
 }

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagTest.kt
@@ -1,0 +1,26 @@
+package no.nav.bidrag.grunnlag
+
+import no.nav.bidrag.grunnlag.BidragGrunnlagTest.Companion.TEST_PROFILE
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.test.context.ActiveProfiles
+
+
+@SpringBootApplication
+@ActiveProfiles(TEST_PROFILE)
+@ComponentScan(excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = [BidragGrunnlag::class, BidragGrunnlagLocal::class])])
+class BidragGrunnlagTest {
+
+  companion object {
+    const val TEST_PROFILE = "test"
+  }
+}
+
+fun main(args: Array<String>) {
+  val profile = if (args.isEmpty()) TEST_PROFILE else args[0]
+  val app = SpringApplication(BidragGrunnlagTest::class.java)
+  app.setAdditionalProfiles(profile)
+  app.run(*args)
+}

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagTestConfig.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/BidragGrunnlagTestConfig.kt
@@ -1,8 +1,14 @@
 package no.nav.bidrag.grunnlag
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import no.nav.bidrag.commons.web.test.HttpHeaderTestRestTemplate
-import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.TEST_PROFILE
+import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.LOCAL_PROFILE
+import no.nav.bidrag.grunnlag.BidragGrunnlagTest.Companion.TEST_PROFILE
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
+import no.nav.security.token.support.spring.validation.interceptor.JwtTokenHandlerInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.context.annotation.Bean
@@ -12,7 +18,11 @@ import org.springframework.http.HttpHeaders
 
 
 @Configuration
-@Profile(TEST_PROFILE)
+@OpenAPIDefinition(
+    info = Info(title = "bidrag-grunnlag", version = "v1"),
+    security = [SecurityRequirement(name = "bearer-key")]
+)
+@Profile(TEST_PROFILE, LOCAL_PROFILE)
 class BidragGrunnlagTestConfig {
 
     @Autowired

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/controller/GrunnlagspakkeControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/controller/GrunnlagspakkeControllerTest.kt
@@ -3,8 +3,8 @@ package no.nav.bidrag.grunnlag.controller
 import no.nav.bidrag.commons.ExceptionLogger
 import no.nav.bidrag.commons.web.HttpHeaderRestTemplate
 import no.nav.bidrag.gcp.proxy.consumer.inntektskomponenten.response.HentAinntektListeResponse
-import no.nav.bidrag.grunnlag.BidragGrunnlagLocal
-import no.nav.bidrag.grunnlag.BidragGrunnlagLocal.Companion.TEST_PROFILE
+import no.nav.bidrag.grunnlag.BidragGrunnlagTest
+import no.nav.bidrag.grunnlag.BidragGrunnlagTest.Companion.TEST_PROFILE
 import no.nav.bidrag.grunnlag.TestUtil
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.GrunnlagstypeRequest
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.HentKomplettGrunnlagspakkeResponse
@@ -54,7 +54,7 @@ import java.time.LocalDate
 
 @DisplayName("GrunnlagspakkeControllerTest")
 @ActiveProfiles(TEST_PROFILE)
-@SpringBootTest(classes = [BidragGrunnlagLocal::class], webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = [BidragGrunnlagTest::class], webEnvironment = WebEnvironment.RANDOM_PORT)
 @EnableMockOAuth2Server
 @AutoConfigureWireMock(port = 0)
 class GrunnlagspakkeControllerTest(

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/service/GrunnlagspakkeServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/service/GrunnlagspakkeServiceTest.kt
@@ -1,6 +1,6 @@
 package no.nav.bidrag.grunnlag.service
 
-import no.nav.bidrag.grunnlag.BidragGrunnlagLocal
+import no.nav.bidrag.grunnlag.BidragGrunnlagTest
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.GrunnlagstypeRequest
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.LukkGrunnlagspakkeRequest
 import no.nav.bidrag.grunnlag.api.grunnlagspakke.OppdaterGrunnlagspakkeRequest
@@ -30,9 +30,9 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @DisplayName("GrunnlagspakkeServiceTest")
-@ActiveProfiles(BidragGrunnlagLocal.TEST_PROFILE)
+@ActiveProfiles(BidragGrunnlagTest.TEST_PROFILE)
 @SpringBootTest(
-  classes = [BidragGrunnlagLocal::class],
+  classes = [BidragGrunnlagTest::class],
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @EnableMockOAuth2Server

--- a/src/test/resources/application-local.yaml
+++ b/src/test/resources/application-local.yaml
@@ -1,0 +1,49 @@
+FAMILIEBASAK_URL: http://localhost:${wiremock.server.https-port}/familiebasak
+BIDRAGGCPPROXY_URL: http://localhost:${wiremock.server.https-port}/bidraggcpproxy
+spring:
+  config.activate.on-profile: local
+  flyway.enabled: false
+  datasource.type: com.zaxxer.hikari.HikariDataSource
+  datasource.url: jdbc:h2:mem:default
+  #  datasource.url: jdbc:h2:file:/Users/R153961/Dev/bidrag-grunnlag/src/main/resources/data
+  h2.console.enabled: true
+  jpa.hibernate.hbmddl-auto: create-drop
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:${mock-oauth2-server.port}/azure
+      client:
+        registration:
+          familiebasak:
+            provider: aad
+            client-id: someid
+            client-secret: secret
+            authorization-grant-type: client_credentials
+            scope: api://familiebasak/.default
+          bidraggcpproxy:
+            provider: aad
+            client-id: someid
+            client-secret: secret
+            authorization-grant-type: client_credentials
+            scope: api://bidraggcpproxy/.default
+        provider:
+          aad:
+            token-uri: http://localhost:${mock-oauth2-server.port}/azure/token
+            jwk-set-uri: http://localhost:${mock-oauth2-server.port}/azure/jwks
+
+no.nav.security.jwt:
+  issuer:
+    aad:
+      discovery_url: http://localhost:${mock-oauth2-server.port}/aad/.well-known/openid-configuration
+      accepted_audience: aud-localhost
+spring.kafka:
+  properties:
+    schema:
+      registry.url: http://unused-dummy-url
+      security.protocol: PLAINTEXT
+  consumer:
+    group-id: test
+    auto-offset-reset: earliest
+    key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    value-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
* Har endret navn på `BidragGrunnlagLocal` -> `BidragGrunnlagTest` (Klassen brukes i de fleste tester) og opprettet en ny klasse `BidragGrunnlagLocal` for bruk når vi ønsker å kjøre opp applikasjonen lokalt.
* Satt opp wiremock med `MockOAuth2Server` og lagt til en ny profil `local` sammen med `application-local` for spesifikke lokale properties.
* Kan nå kjøre opp appen lokalt og teste i swagger. Token kan genereres med endepunktet `local/cookie` som også ligger i swagger og som er en del av `MockOAuth2Server`. Ende til ende fungerer ikke, men vi kan ihvertfall teste applikasjonslogikk frem til rest-kall videre bakover osv. Hvis vi vil kan vi også sette sette opp mock for de ulike tjenestene vi kaller bakover i fremtiden.