### PR TITLE
Added info on how to issue valid aad jwt token in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,35 @@ Miljøer:
 * GCP-DEV ([https://bidrag-grunnlag.dev.intern.nav.no/bidrag-grunnlag/](https://bidrag-grunnlag.dev.intern.nav.no/bidrag-grunnlag/))
 * GCP-PROD ([https://bidrag-grunnlag.intern.nav.no/bidrag-grunnlag/](https://bidrag-grunnlag.intern.nav.no/bidrag-grunnlag/))
 
+## Utstede gyldig token i gcp-dev
+For å kunne teste applikasjonen i `gcp-dev` trenger man et gyldig AzureAD JWT-token. For å utstede et slikt token trenger man miljøvariablene `AZURE_APP_CLIENT_ID` og `AZURE_APP_CLIENT_SECRET`. Disse ligger tilgjengelig i de kjørene pod'ene til applikasjonen.
+
+Koble seg til en kjørende pod (feature-branch):
+```
+kubectl -n bidrag exec -i -t bidrag-grunnlag-feature-<sha> -c bidrag-grunnlag-feature -- /bin/bash
+```
+
+Koble seg til en kjørende pod (main-branch):
+```
+kubectl -n bidrag exec -i -t bidrag-grunnlag-<sha> -c bidrag-grunnlag -- /bin/bash
+```
+
+Når man er inne i pod'en kan man hente ut miljøvariablene på følgende måte:
+```
+echo "$( cat /var/run/secrets/nais.io/azure/AZURE_APP_CLIENT_ID )"
+echo "$( cat /var/run/secrets/nais.io/azure/AZURE_APP_CLIENT_SECRET )"
+```
+
+Deretter kan vi hente ned et gyldig Azure AD JWT-token med følgende kall (feature-branch): 
+```
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d 'client_id=<AZURE_APP_CLIENT_ID>&scope=api://dev-gcp.bidrag.bidrag-grunnlag-feature/.default&client_secret=<AZURE_APP_CLIENT_SECRET>&grant_type=client_credentials' 'https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token'
+```
+
+Deretter kan vi hente ned et gyldig Azure AD JWT-token med følgende kall (main-branch):
+```
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d 'client_id=<AZURE_APP_CLIENT_ID>&scope=api://dev-gcp.bidrag.bidrag-grunnlag/.default&client_secret=<AZURE_APP_CLIENT_SECRET>&grant_type=client_credentials' 'https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token'
+```
+
 ## Kjøre applikasjon lokalt
 En fullstendig fungerende applikasjon kan for øyeblikket ikke kjøres opp lokalt på egen maskin da vi ikke har mulighet til å kommunisere med eksterne tjenester. Applikasjonen kan allikevel kjøres opp for å teste endepunkter fra Swagger ([http://localhost:8080/bidrag-grunnlag](http://localhost:8080/bidrag-grunnlag)) og annen logikk i applikasjonen som er uavhengig av kontakt med eksterne tjenester. Operasjoner som går rett mot databasen, som opprettelse og henting av grunnlagspakker, vil også fungere ved hjelp av in-memory databasen H2.
 


### PR DESCRIPTION
* Lagt til litt dokumentasjon på hvordan man kan få få utstedt et gyldig AzureAD token i dev

Laget en PR da jeg er usikker på om denne informasjonen potensielt er sensitiv og om den kanskje ikke skal være en del av README. Tror selv det er helt innafor, men var altså ikke helt sikker 😛 