### PR TITLE
Feature/diverse oppgradering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@
 
 Tjeneste for innhenting av grunnlag i bidragssaker. Tjenesten er sentrert rundt begrepet `grunnlagspakke`, som fungerer som en beholder for alle grunnlag tilknyttet en bestemt bidragssak. Konsumenter av tjenesten kan opprette grunnlagspakker og bestemme hvilke grunnlag og perioder som skal hentes for de ulike partene. Tjenesten vil hente alle ønskede grunnlag og knytte de opp mot opprettet grunnlagspakke. Grunnlagspakken kan deretter hentes ut med alle tilhørende grunnlag. Frem til det er fattet et vedtak i en bidragssak tilknyttet en grunnlagspakke, kan alle grunnlagene oppdateres og/eller endres.
 
+For de grunnlagene som er relatert til inntekt og som potensielt inneholder flere underposter (A-inntekt og Skattegrunnlag), gjøres det en sammenligning mot eksisterende forekomster når det blir kjørt en oppdatering av grunnlagspakke. Hvis de(n) nye forekomsten(e) som hentes er identisk(e) med de(n) som er hentet fra før, oppdateres kun timestamp på eksisterende forekomst(er). For alle andre grunnlagstyper blir det ikke gjort noen sammenligning. Her insertes det ny(e) forekomst(er) og eksisterende forekomst(er) settes til aktiv=false og gyldigTil=current timestamp.
+
 Støtter foreløpig følgende grunnlag:
-* Inntekt
+* A-inntekt
 * Skattegrunnlag
 * Utvidet barnetrygd og småbarnstillegg
+* Barnetillegg fra Pensjon
 * ... resterende grunnlag legges til fortløpende
 
 Miljøer:

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
 
   <properties>
     <!-- build/language -->
-    <kotlin.version>1.5.31</kotlin.version>
+    <kotlin.version>1.6.10</kotlin.version>
     <build-helper-maven.version>3.2.0</build-helper-maven.version>
     <token-support.version>1.3.9</token-support.version>
 
     <!-- dependencies -->
-    <bidrag-commons.version>0.5.16</bidrag-commons.version>
+    <bidrag-commons.version>0.5.19</bidrag-commons.version>
     <bidrag-commons-test.version>0.2.2</bidrag-commons-test.version>
     <bidrag-tilgangskontroll.version>1.9.20</bidrag-tilgangskontroll.version>
     <mockito-kotlin.version>4.0.0</mockito-kotlin.version>

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/api/grunnlagspakke/OppdaterGrunnlagspakkeRequest.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/api/grunnlagspakke/OppdaterGrunnlagspakkeRequest.kt
@@ -1,14 +1,10 @@
 package no.nav.bidrag.grunnlag.api.grunnlagspakke
 
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDate
 import javax.validation.Valid
 import javax.validation.constraints.NotEmpty
 
 data class OppdaterGrunnlagspakkeRequest(
-
-  @Schema(description = "Opplysningene som hentes er gyldige til (men ikke med) denne datoen (YYYY-MM-DD")
-  val gyldigTil: LocalDate? = null,
 
   @Schema(description = "Liste over hvilke typer grunnlag som skal hentes inn. På nivået under er personId og perioder angitt")
   @field:Valid

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/AinntektRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/AinntektRepository.kt
@@ -2,21 +2,12 @@ package no.nav.bidrag.grunnlag.persistence.repository
 
 import no.nav.bidrag.grunnlag.persistence.entity.Ainntekt
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface AinntektRepository : JpaRepository<Ainntekt, Int?> {
 
   @Query(
-//    "select inta from Ainntekt inta where inta.grunnlagspakkeId = :grunnlagspakkeId"
     "select ain from Ainntekt ain where ain.grunnlagspakkeId = :grunnlagspakkeId and ain.aktiv = true"
   )
   fun hentAinntekter(grunnlagspakkeId: Int): List<Ainntekt>
-
-  @Query(
-    "update Ainntekt ain set ain.aktiv = false, ain.brukTil = CURRENT_TIMESTAMP where ain.inntektId = :inntektId"
-  )
-  @Modifying
-  fun settInntektSomInaktiv(inntektId: Int)
-
 }

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/AinntektspostRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/AinntektspostRepository.kt
@@ -10,5 +10,4 @@ interface AinntektspostRepository : JpaRepository<Ainntektspost, Int?> {
     "select ainp from Ainntektspost ainp where ainp.inntektId = :inntektId order by ainp.utbetalingsperiode, ainp.inntektType"
   )
   fun hentInntektsposter(inntektId: Int): List<Ainntektspost>
-
 }

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/BarnetilleggRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/BarnetilleggRepository.kt
@@ -2,13 +2,27 @@ package no.nav.bidrag.grunnlag.persistence.repository
 
 import no.nav.bidrag.grunnlag.persistence.entity.Barnetillegg
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface BarnetilleggRepository : JpaRepository<Barnetillegg, Int?> {
 
   @Query(
     "select bt from Barnetillegg bt where bt.grunnlagspakkeId = :grunnlagspakkeId and bt.aktiv = true"
   )
-
   fun hentBarnetillegg(grunnlagspakkeId: Int): List<Barnetillegg>
+
+  @Modifying
+  @Query(
+    "update Barnetillegg bt " +
+        "set bt.aktiv = false, bt.brukTil = :timestampOppdatering " +
+        "where bt.grunnlagspakkeId = :grunnlagspakkeId and bt.partPersonId = :partPersonId and bt.barnetilleggType = :barnetilleggType and bt.aktiv = true"
+  )
+  fun oppdaterEksisterendeBarnetilleggTilInaktiv(
+    grunnlagspakkeId: Int,
+    partPersonId: String,
+    timestampOppdatering: LocalDateTime,
+    barnetilleggType: String
+  )
 }

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/GrunnlagspakkeRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/GrunnlagspakkeRepository.kt
@@ -4,34 +4,24 @@ import no.nav.bidrag.grunnlag.persistence.entity.Grunnlagspakke
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 interface GrunnlagspakkeRepository : JpaRepository<Grunnlagspakke, Int?> {
 
-  @Query(
-    "select gp from Grunnlagspakke gp where gp.grunnlagspakkeId = :grunnlagspakkeId"
-  )
-  fun hentGrunnlagspakke(grunnlagspakkeId: Int): Grunnlagspakke
-
-
+  @Modifying
   @Query(
     "update Grunnlagspakke gp set gp.gyldigTil = current_date where gp.grunnlagspakkeId = :grunnlagspakkeId"
   )
-  @Modifying
   fun lukkGrunnlagspakke(grunnlagspakkeId: Int)
-
 
   @Query(
     "select gp.formaal from Grunnlagspakke gp where gp.grunnlagspakkeId = :grunnlagspakkeId"
   )
   fun hentFormaalGrunnlagspakke(grunnlagspakkeId: Int): String
 
-
+  @Modifying
   @Query(
     "update Grunnlagspakke gp set gp.endretTimestamp = :timestampOppdatering where gp.grunnlagspakkeId = :grunnlagspakkeId"
   )
-  @Modifying
   fun oppdaterEndretTimestamp(grunnlagspakkeId: Int, timestampOppdatering: LocalDateTime)
 }
-

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/SkattegrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/SkattegrunnlagRepository.kt
@@ -2,7 +2,6 @@ package no.nav.bidrag.grunnlag.persistence.repository
 
 import no.nav.bidrag.grunnlag.persistence.entity.Skattegrunnlag
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface SkattegrunnlagRepository : JpaRepository<Skattegrunnlag, Int?> {
@@ -11,10 +10,4 @@ interface SkattegrunnlagRepository : JpaRepository<Skattegrunnlag, Int?> {
       "select sg from Skattegrunnlag sg where sg.grunnlagspakkeId = :grunnlagspakkeId and sg.aktiv = true"
   )
   fun hentSkattegrunnlag(grunnlagspakkeId: Int): List<Skattegrunnlag>
-
-  @Query(
-      "update Skattegrunnlag sg set sg.aktiv = false, sg.brukTil = CURRENT_TIMESTAMP where sg.skattegrunnlagId = :inntektId"
-  )
-  @Modifying
-  fun settSkattegrunnlagSomInaktiv(inntektId: Int)
 }

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/SkattegrunnlagspostRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/SkattegrunnlagspostRepository.kt
@@ -10,5 +10,4 @@ interface SkattegrunnlagspostRepository : JpaRepository<Skattegrunnlagspost, Int
       "select sgp from Skattegrunnlagspost sgp where sgp.skattegrunnlagId = :inntektId"
   )
   fun hentSkattegrunnlagsposter(inntektId: Int): List<Skattegrunnlagspost>
-
 }

--- a/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/UtvidetBarnetrygdOgSmaabarnstilleggRepository.kt
+++ b/src/main/kotlin/no/nav/bidrag/grunnlag/persistence/repository/UtvidetBarnetrygdOgSmaabarnstilleggRepository.kt
@@ -2,7 +2,9 @@ package no.nav.bidrag.grunnlag.persistence.repository
 
 import no.nav.bidrag.grunnlag.persistence.entity.UtvidetBarnetrygdOgSmaabarnstillegg
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface UtvidetBarnetrygdOgSmaabarnstilleggRepository : JpaRepository<UtvidetBarnetrygdOgSmaabarnstillegg, Int?> {
 
@@ -11,6 +13,11 @@ interface UtvidetBarnetrygdOgSmaabarnstilleggRepository : JpaRepository<UtvidetB
   )
   fun hentUbst(grunnlagspakkeId: Int): List<UtvidetBarnetrygdOgSmaabarnstillegg>
 
-
-
+  @Modifying
+  @Query(
+    "update UtvidetBarnetrygdOgSmaabarnstillegg ubst " +
+        "set ubst.aktiv = false, ubst.brukTil = :timestampOppdatering " +
+        "where ubst.grunnlagspakkeId = :grunnlagspakkeId and ubst.personId = :personId and ubst.aktiv = true"
+  )
+  fun oppdaterEksisterendeUtvidetBarnetrygOgSmaabarnstilleggTilInaktiv(grunnlagspakkeId: Int, personId: String, timestampOppdatering: LocalDateTime)
 }

--- a/src/main/resources/db/migration/V1_0_17__alter-table-barnetillegg-add-index.sql
+++ b/src/main/resources/db/migration/V1_0_17__alter-table-barnetillegg-add-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_barnetillegg_1 ON barnetillegg(grunnlagspakke_id, aktiv);

--- a/src/main/resources/db/migration/V1_0_18__grant-all-on-tables.sql
+++ b/src/main/resources/db/migration/V1_0_18__grant-all-on-tables.sql
@@ -1,0 +1,1 @@
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/TestUtil.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/TestUtil.kt
@@ -60,7 +60,6 @@ class TestUtil {
     )
 
     fun byggOppdaterGrunnlagspakkeRequestKomplett() = OppdaterGrunnlagspakkeRequest(
-      gyldigTil = LocalDate.parse("2021-08-01"),
       grunnlagRequestListe = listOf(
         GrunnlagRequest(
           grunnlagType = GrunnlagType.AINNTEKT,
@@ -90,7 +89,6 @@ class TestUtil {
     )
 
     fun byggOppdaterGrunnlagspakkeRequestUtvidetBarnetrygd() = OppdaterGrunnlagspakkeRequest(
-      gyldigTil = LocalDate.parse("2021-08-01"),
       grunnlagRequestListe = listOf(
         GrunnlagRequest(
           grunnlagType = GrunnlagType.UTVIDETBARNETRYGDOGSMAABARNSTILLEGG,
@@ -102,7 +100,6 @@ class TestUtil {
     )
 
     fun byggOppdaterGrunnlagspakkeRequestBarnetillegg() = OppdaterGrunnlagspakkeRequest(
-      gyldigTil = LocalDate.parse("2021-08-01"),
       grunnlagRequestListe = listOf(
         GrunnlagRequest(
           grunnlagType = GrunnlagType.BARNETILLEGG,

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/controller/GrunnlagspakkeControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/controller/GrunnlagspakkeControllerTest.kt
@@ -269,20 +269,15 @@ class GrunnlagspakkeControllerTest(
     assertNotNull(errorResult)
     assertNotNull(errorResult["grunnlagspakkeId"])
 
-    errorResult = performExpectedFailingRequest("/requests/oppdaterGrunnlagspakke2.json", "/grunnlagspakke/Test/oppdater")
+    errorResult = performExpectedFailingRequest("/requests/oppdaterGrunnlagspakke1.json", "/grunnlagspakke/Test/oppdater")
 
     assertNotNull(errorResult)
     assertNotNull(errorResult["grunnlagspakkeId"])
 
-    errorResult = performExpectedFailingRequest("/requests/oppdaterGrunnlagspakke3.json", "/grunnlagspakke/1/oppdater")
+    errorResult = performExpectedFailingRequest("/requests/oppdaterGrunnlagspakke1.json", "/grunnlagspakke/1/oppdater")
 
     assertNotNull(errorResult)
     assertNotNull(errorResult["grunnlagRequestListe"])
-
-    errorResult = performExpectedFailingRequest("/requests/oppdaterGrunnlagspakke4.json", "/grunnlagspakke/1/oppdater")
-
-    assertNotNull(errorResult)
-    assertNotNull(errorResult["gyldigTil"])
 
     errorResult = performExpectedFailingRequest("/requests/oppdaterGrunnlagspakke5.json", "/grunnlagspakke/1/oppdater")
 
@@ -317,7 +312,6 @@ class GrunnlagspakkeControllerTest(
       grunnlagspakkeService.oppdaterGrunnlagspakke(
         1,
         OppdaterGrunnlagspakkeRequest(
-          gyldigTil = LocalDate.parse("2022-01-01"),
           grunnlagRequestListe = listOf(
             GrunnlagRequest(
               grunnlagType = GrunnlagType.UTVIDETBARNETRYGDOGSMAABARNSTILLEGG,

--- a/src/test/kotlin/no/nav/bidrag/grunnlag/service/GrunnlagspakkeServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/grunnlag/service/GrunnlagspakkeServiceTest.kt
@@ -233,7 +233,7 @@ class GrunnlagspakkeServiceTest {
         grunnlagspakkeId = nyGrunnlagspakkeOpprettet.grunnlagspakkeId,
         partPersonId = "22334455",
         barnPersonId = "1234567",
-        barnetilleggType = "Utvidet barnetrygd",
+        barnetilleggType = BarnetilleggType.PENSJON.toString(),
         periodeFra = LocalDate.parse("2021-05-01"),
         periodeTil = LocalDate.parse("2021-06-01"),
         belopBrutto = BigDecimal.valueOf(1000.01)
@@ -314,7 +314,7 @@ class GrunnlagspakkeServiceTest {
       Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe.size).isEqualTo(1) },
       Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].partPersonId).isEqualTo("22334455") },
       Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].barnPersonId).isEqualTo("1234567") },
-      Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].barnetilleggType).isEqualTo("Utvidet barnetrygd") },
+      Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].barnetilleggType).isEqualTo(BarnetilleggType.PENSJON.toString()) },
       Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].periodeFra).isEqualTo(LocalDate.parse("2021-05-01")) },
       Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].periodeTil).isEqualTo(LocalDate.parse("2021-06-01")) },
       Executable { assertThat(komplettGrunnlagspakkeFunnet.barnetilleggListe[0].aktiv).isEqualTo(true) },

--- a/src/test/resources/requests/oppdaterGrunnlagspakke1.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke1.json
@@ -1,4 +1,3 @@
 {
-  "gyldigTil": null,
   "grunnlagRequestListe": []
 }

--- a/src/test/resources/requests/oppdaterGrunnlagspakke10.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke10.json
@@ -1,5 +1,4 @@
 {
-  "gyldigTil": "2022-01-01",
   "grunnlagRequestListe": [
     {
       "grunnlagType": "UTVIDETBARNETRYGDOGSMAABARNSTILLEGG",

--- a/src/test/resources/requests/oppdaterGrunnlagspakke2.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke2.json
@@ -1,4 +1,0 @@
-{
-  "gyldigTil": null,
-  "grunnlagRequestListe": []
-}

--- a/src/test/resources/requests/oppdaterGrunnlagspakke3.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke3.json
@@ -1,4 +1,0 @@
-{
-  "gyldigTil": null,
-  "grunnlagRequestListe": []
-}

--- a/src/test/resources/requests/oppdaterGrunnlagspakke4.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke4.json
@@ -1,4 +1,0 @@
-{
-  "gyldigTil": "01-01-2022",
-  "grunnlagRequestListe": []
-}

--- a/src/test/resources/requests/oppdaterGrunnlagspakke5.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke5.json
@@ -1,5 +1,4 @@
 {
-  "gyldigTil": "2022-01-01",
   "grunnlagRequestListe": [
     {
       "grunnlagType": "grunnlagstype",

--- a/src/test/resources/requests/oppdaterGrunnlagspakke6.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke6.json
@@ -1,5 +1,4 @@
 {
-  "gyldigTil": "2022-01-01",
   "grunnlagRequestListe": [
     {
       "grunnlagType": "UTVIDETBARNETRYGDOGSMAABARNSTILLEGG"

--- a/src/test/resources/requests/oppdaterGrunnlagspakke7.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke7.json
@@ -1,5 +1,4 @@
 {
-  "gyldigTil": "2022-01-01",
   "grunnlagRequestListe": [
     {
       "grunnlagType": "UTVIDETBARNETRYGDOGSMAABARNSTILLEGG",

--- a/src/test/resources/requests/oppdaterGrunnlagspakke8.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke8.json
@@ -1,5 +1,4 @@
 {
-  "gyldigTil": "2022-01-01",
   "grunnlagRequestListe": [
     {
       "grunnlagType": "UTVIDETBARNETRYGDOGSMAABARNSTILLEGG",

--- a/src/test/resources/requests/oppdaterGrunnlagspakke9.json
+++ b/src/test/resources/requests/oppdaterGrunnlagspakke9.json
@@ -1,5 +1,4 @@
 {
-  "gyldigTil": "2022-01-01",
   "grunnlagRequestListe": [
     {
       "grunnlagType": "UTVIDETBARNETRYGDOGSMAABARNSTILLEGG",


### PR DESCRIPTION
- Ved oppdaterGrunnlagspakke settes gamle forekomster til aktiv=false og brukTil=current timestamp (gjelder barnetillegg og ubst)
- Synkronisering av timestamp mellom GrunnlagspakkeService og PersistenceService
- Fjernet gyldigTil fra oppdaterGrunnlagspakke
- Fjernet metoder som ikke var i bruk
- Lagt inn oppdatering av grunnlagspakke.endret_timestamp når oppdaterGrunnlagspakke blir kalt